### PR TITLE
Fixing the omxplayer fullscren focus problem

### DIFF
--- a/kano_video/logic/player.py
+++ b/kano_video/logic/player.py
@@ -14,6 +14,8 @@ from kano.utils import write_file_contents, is_installed, \
 from kano.logging import logger
 from .youtube import get_video_file_url
 
+import playudev
+
 subtitles_dir = '/usr/share/kano-media/videos/subtitles'
 
 omxplayer_present = is_installed('omxplayer')
@@ -76,11 +78,11 @@ def play_video(_button=None, video_url=None, localfile=None,
             '--align center'.format(subtitles=subtitles)
 
         if fullscreen:
-            player_cmd = 'lxterminal -e "omxplayer {hdmi_str} {volume_str} ' \
+            player_cmd = 'omxplayer {hdmi_str} {volume_str} ' \
                 '{subtitles} -b ' \
-                '\\"{link}\\""'.format(link=link, hdmi_str=hdmi_str,
-                                       volume_str=volume_str,
-                                       subtitles=subtitles_str)
+                '"{link}"'.format(link=link, hdmi_str=hdmi_str,
+                                  volume_str=volume_str,
+                                  subtitles=subtitles_str)
         else:
             x1, y1, x2, y2 = get_centred_coords(width=width, height=height)
 
@@ -113,7 +115,12 @@ def play_video(_button=None, video_url=None, localfile=None,
         player_cmd = '/usr/bin/kdesk-blur \'{}\''.format(player_cmd)
 
     if wait:
-        run_cmd(player_cmd)
+        if fullscreen and omxplayer_present:
+            # Play with keyboard interaction coming from udev directly
+            # so that we do not lose focus and capture all key presses
+            playudev.run_player(player_cmd)
+        else:
+            run_cmd(player_cmd)
     else:
         run_bg(player_cmd)
 

--- a/kano_video/logic/playudev.py
+++ b/kano_video/logic/playudev.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python
+
+# playudev.py
+#
+# Copyright (C) 2014 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+#
+# Play media using omxplayer, but listening for keyboard events from udev directly
+#
+
+import struct
+import subprocess
+import threading
+
+
+def wait_for_keys (pomx):
+    '''
+    Listens for keyboard events from /dev/input
+    translates Q and Space to omxplayer via its stdin.
+    pomx is a subprocess Popen object.
+    '''
+
+    # FIXME: Eventually event0 is eventX on some keyboards
+    infile_path = "/dev/input/event0"
+
+    #long int, long int, unsigned short, unsigned short, unsigned int
+    FORMAT = 'llHHI'
+    EVENT_SIZE = struct.calcsize(FORMAT)
+
+    #open file in binary mode
+    in_file = open(infile_path, "rb")
+
+    event = in_file.read(EVENT_SIZE)
+
+    while event:
+        (tv_sec, tv_usec, type, code, value) = struct.unpack(FORMAT, event)
+
+        if type == 1 and code == 16 and value == 0:
+            # The key "q" has been released, quit omxplayer
+            pomx.stdin.write('q')
+            pomx.stdin.flush()
+
+            # finish the thread
+            break
+
+        if type == 1 and code == 57 and value == 0:
+            # The space key has been released, pause/resume the media
+            pomx.stdin.write(' ')
+            pomx.stdin.flush()
+
+        event = in_file.read(EVENT_SIZE)
+
+    in_file.close()
+
+def run_player (cmdline):
+    '''
+    Start omxplayer giving us the stdin pipe to speak to him.
+    '''
+    pomx = subprocess.Popen(cmdline, stdin=subprocess.PIPE, shell=True)
+
+    # A thread will listen for key events and send them to OMXPlayer
+    t = threading.Thread(target=wait_for_keys, args=(pomx,))
+    t.daemon = True
+    t.start()
+
+    rc = pomx.wait()
+    return rc


### PR DESCRIPTION
- Replacing regular playing fullscreen using omxplayer, by playudev instead
- playudev starts omxplayer conserving its stdin, then listens for keyboard events from
  udev on a separate thread. Space and Q keys are sent to its stdin
- Removed lxterminal in this case as we do not need to worry about who has the focus.
