### PR TITLE
Fixing kano-video app eventually becoming all white, minor mouse movemen...

### DIFF
--- a/bin/kano-video
+++ b/bin/kano-video
@@ -4,7 +4,7 @@
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
 #
 
-from gi.repository import Gtk, Gdk
+from gi.repository import Gtk, Gdk, GObject
 import os
 import sys
 
@@ -28,6 +28,8 @@ def main():
     screen = Gdk.Screen.get_default()
     styleContext = Gtk.StyleContext()
     styleContext.add_provider_for_screen(screen, cssProvider, Gtk.STYLE_PROVIDER_PRIORITY_USER)
+
+    GObject.threads_init()
 
     win = MainWindow()
     win.connect('delete-event', Gtk.main_quit)

--- a/kano_video/logic/player.py
+++ b/kano_video/logic/player.py
@@ -31,7 +31,7 @@ if not omxplayer_present and not vlc_present:
     sys.exit('Neither vlc nor omxplayer is installed!')
 
 
-def play_video(_button=None, video_url=None, localfile=None, subtitles=None):
+def play_video(_button=None, video_url=None, localfile=None, subtitles=None, init_threads=True):
 
     if video_url:
         logger.info('Getting video url: {}'.format(video_url))
@@ -96,7 +96,7 @@ def play_video(_button=None, video_url=None, localfile=None, subtitles=None):
 
     # Play with keyboard interaction coming from udev directly
     # so that we do not lose focus and capture all key presses
-    playudev.run_player(player_cmd)
+    playudev.run_player(player_cmd, init_threads)
 
     # finally, enable the button back again
     if _button:

--- a/kano_video/logic/playudev.py
+++ b/kano_video/logic/playudev.py
@@ -23,8 +23,6 @@ except ImportError:
     import gtk.gdk as Gdk
     import gobject as GObject
 
-GObject.threads_init()
-
 
 def get_keyboard_input_device(fdevice_list='/proc/bus/input/devices'):
     '''
@@ -153,11 +151,14 @@ class VideoKeyboardEngulfer(Gtk.Window):
         t.start()
 
 
-def run_player(cmdline):
+def run_player(cmdline, init_threads=True):
     '''
     A popup window in full screen mode will engulf all key and mouse events
     so that underlying windows do not get unintentional input.
     '''
+    if init_threads:
+        GObject.threads_init()
+
     win = VideoKeyboardEngulfer(cmdline)
     win.connect("destroy", Gtk.main_quit)
     win.show_all()

--- a/kano_video/ui/video.py
+++ b/kano_video/ui/video.py
@@ -8,7 +8,7 @@
 
 import threading
 
-from gi.repository import Gtk, Gdk, GObject
+from gi.repository import Gtk, Gdk
 from urllib import urlretrieve
 from time import time
 from random import randint
@@ -26,9 +26,6 @@ from kano_video.logic.playlist import playlistCollection, \
 
 from .popup import AddToPlaylistPopup
 from .general import Spacer, RemoveButton, Button
-
-
-GObject.threads_init()
 
 
 class VideoEntry(Gtk.Button):
@@ -110,7 +107,7 @@ class VideoEntry(Gtk.Button):
         _button.set_sensitive(False)
 
         # start the video playing thread - this will enable the button back again
-        t = threading.Thread(target=play_video, args=(_button, _url, _localfile,))
+        t = threading.Thread(target=play_video, args=(_button, _url, _localfile, None, False))
         t.daemon = True
         t.start()
 
@@ -219,7 +216,7 @@ class VideoDetailEntry(Gtk.Button):
         _button.set_sensitive(False)
 
         # start the video playing thread - this will enable the button back again
-        t = threading.Thread(target=play_video, args=(_button, _url, _localfile,))
+        t = threading.Thread(target=play_video, args=(_button, _url, _localfile, None, False))
         t.daemon = True
         t.start()
 
@@ -359,6 +356,6 @@ class VideoListPopular(VideoList):
         _button.set_sensitive(False)
 
         # start the video playing thread - this will enable the button back again
-        t = threading.Thread(target=play_video, args=(_button, _url,))
+        t = threading.Thread(target=play_video, args=(_button, _url, None, False))
         t.daemon = True
         t.start()


### PR DESCRIPTION
...t issue
- Gtk objects cannot be manipulated by other threads. Gobject’s idle_add comes to address this limitation (used to re-enable buttons)
- If you only clicked on the “watch” link, video would not start playing until you move the mouse at least 1 pixel.
  Fixed by removing calls to Gtk.main_iteration_do.
- I tried to simplify Gtk dependencies to only import Gobject but eventually app crashes with FatalIO error (added dependents Gtk and Gdk).
- removed unnecessary run_cmd import
