### PR TITLE
Fixes proxy_arg not being defined if there is no proxy.

### DIFF
--- a/kano_video/logic/youtube.py
+++ b/kano_video/logic/youtube.py
@@ -14,6 +14,8 @@ from kano.logging import logger
 tmp_dir = '/tmp/kano-video'
 last_search_count = 0
 
+proxy_arg = ''
+
 try:
     from kano_settings.system.proxy import generate_proxy_url, \
         get_all_proxies
@@ -25,7 +27,7 @@ try:
             proxy['username'], proxy['password'])
         proxy_arg = '--proxy "{}"'.format(proxy_url)
 except ImportError:
-    proxy_arg = ''
+    pass
 
 
 def page_to_index(page, max_results=10):


### PR DESCRIPTION
Whenever I tried to play a video with no proxy, it failed with the error

```
global name 'proxy_arg' is not defined
```

This should fix that

@zsero 
