### PR TITLE
Fixing a formatting typo

### DIFF
--- a/kano_video/logic/playlist.py
+++ b/kano_video/logic/playlist.py
@@ -118,7 +118,7 @@ class PlaylistCollection(object):
             shutil.copy(os.path.join(playlist_path + '/Library.json'),
                         playlist_dir)
             # Kano contains online videos that are useful to users
-            shutil.copy(os.path.join(playlist_path, '/Kano.json'),
+            shutil.copy(os.path.join(playlist_path + '/Kano.json'),
                         playlist_dir)
         except shutil.Error:
             pass


### PR DESCRIPTION
A typo introduced during code formatting.

Related to https://github.com/KanoComputing/peldins/issues/1564

cc @tombettany @alex5imon 

This should fix the problem, @FMog.