### PR TITLE
Associating video files with kano-video-cli

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -6,3 +6,4 @@ icon/video.png /usr/share/kano-video/icon
 icon/video.png /usr/share/icons/Kano/88x88/apps
 icon/youtube.app /usr/share/applications
 kdesktop/kano-video.desktop /usr/share/applications/
+kdesktop/video-cli.desktop /usr/share/applications/

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# postinst
+#
+# Copyright (C) 2014 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+#
+# postinst - things to do after installing the package
+#
+
+# File which tells LXDE which file extensions trigger what apps when double clicked
+associations_file=/usr/share/applications/defaults.list
+
+# Video formats that kano-video-cli should handle
+video_formats="
+3gpp
+3gpp2
+annodex
+dv
+isivideo
+mp2t
+mp4
+mpeg
+ogg
+quicktime
+vivo
+vnd.mpegurl
+vnd.rn-realvideo
+wavelet.xml
+webm
+anim
+flic
+flv
+javafx
+matroska
+mng
+ms-asf
+ms-wmv
+msvideo
+nsv
+ogm+ogg
+sgi-movie
+theora+ogg
+"
+
+case "$1" in
+    configure)
+        # associate video files to kano-video-cli, so double click will watch them
+        for v in $video_formats; do
+            pattern="video/$v=video-cli.desktop"
+            if [ `grep "$pattern" myformats | wc -l` -eq 0 ]; then
+                echo "Registering video format: $pattern"
+                echo "$pattern" >> myformats
+            fi
+        done
+        ;;
+
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/debian/postinst
+++ b/debian/postinst
@@ -10,6 +10,7 @@
 
 # File which tells LXDE which file extensions trigger what apps when double clicked
 associations_file=/usr/share/applications/defaults.list
+updated=0
 
 # Video formats that kano-video-cli should handle
 video_formats="
@@ -48,11 +49,16 @@ case "$1" in
         # associate video files to kano-video-cli, so double click will watch them
         for v in $video_formats; do
             pattern="video/$v=video-cli.desktop"
-            if [ `grep "$pattern" myformats | wc -l` -eq 0 ]; then
+            if [ `grep "$pattern" $associations_file | wc -l` -eq 0 ]; then
                 echo "Registering video format: $pattern"
-                echo "$pattern" >> myformats
+                echo "$pattern" >> $associations_file
+                updated=1
             fi
         done
+
+        if [ "$updated" == "1" ] && [ -x /usr/bin/update-mime-database ]; then
+            /usr/bin/update-mime-database /usr/share/mime
+        fi
         ;;
 
 esac

--- a/kdesktop/video-cli.desktop
+++ b/kdesktop/video-cli.desktop
@@ -1,0 +1,37 @@
+[Desktop Entry]
+Name=Kano Video CLI
+Comment=Play video files from the command line or desktop associations
+Exec=/usr/bin/kano-video-cli
+TryExec=/usr/bin/kano-video-cli
+
+MimeType=video/3gpp
+MimeType=video/3gpp2
+MimeType=video/annodex
+MimeType=video/dv
+MimeType=video/isivideo
+MimeType=video/mp2t
+MimeType=video/mp4
+MimeType=video/mpeg
+MimeType=video/ogg
+MimeType=video/quicktime
+MimeType=video/vivo
+MimeType=video/vnd.mpegurl
+MimeType=video/vnd.rn-realvideo
+MimeType=video/wavelet.xml
+MimeType=video/webm
+MimeType=video/anim
+MimeType=video/flic
+MimeType=video/flv
+MimeType=video/javafx
+MimeType=video/matroska
+MimeType=video/mng
+MimeType=video/ms-asf
+MimeType=video/ms-wmv
+MimeType=video/msvideo
+MimeType=video/nsv
+MimeType=video/ogm+ogg
+MimeType=video/sgi-movie
+MimeType=video/theora+ogg
+
+Icon=/usr/share/kano-video/icon/video.png
+Type=Application


### PR DESCRIPTION
 * A new applications desktop file is appended to handle video mime types
 * LXDE associations list definitions is edited during install
   to register the video formats to be handled by kano-video-cli