### PR TITLE
Video Browser: Point to Kano's channel

### DIFF
--- a/bin/kano-video-browser
+++ b/bin/kano-video-browser
@@ -32,7 +32,11 @@ from kano.network import is_internet
 def main():
 
     # Launch Chromium youtube mode
-    run_cmd("chromium --window-size=900,650 --app=http://www.youtube.com")
+    run_cmd(
+        'chromium '
+        '--window-size=900,650 '
+        '--app=http://www.youtube.com/user/kanoComputing'
+    )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
KanoComputing/os-dashboard#105
Rather than directly loading up YouTube, load Kano's official channel.

cc @alex5imon 